### PR TITLE
chore: upgrade twitter-together action

### DIFF
--- a/.github/workflows/twitter-together.yml
+++ b/.github/workflows/twitter-together.yml
@@ -6,18 +6,18 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: gr2m/twitter-together@v1.x
+      - uses: twitter-together/action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   tweet:
     name: Tweet
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - name: checkout master
-        uses: actions/checkout@v2
+      - name: checkout main
+        uses: actions/checkout@v3
       - name: Tweet
-        uses: gr2m/twitter-together@v1.x
+        uses: twitter-together/action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}

--- a/.github/workflows/twitter-together.yml
+++ b/.github/workflows/twitter-together.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: twitter-together/action@v2
+      - uses: twitter-together/action@f93dc7bfe570755b689d5cf894acf4319aa0e722 # v2.1.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   tweet:
@@ -17,7 +17,7 @@ jobs:
       - name: checkout main
         uses: actions/checkout@v3
       - name: Tweet
-        uses: twitter-together/action@v2
+        uses: twitter-together/action@f93dc7bfe570755b689d5cf894acf4319aa0e722 # v2.1.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}


### PR DESCRIPTION
We need to switch the default branch from master to main on the settings page of this repo.

> I'm not sure if this change is 100% reliable, as I haven't tested it. I am in the process of applying for a Twitter developer account in order to do reliability testing at https://github.com/BlackHole1/test-twitter-together. (`TWITTER_API_KEY` requires a developer to apply.) <img width="1062" alt="image" src="https://user-images.githubusercontent.com/8198408/192249372-a21c35c4-8579-43cb-9791-5eb9a94eed4d.png">

