### PR TITLE
chore: set @wg-outreach as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @electron/wg-outreach


### PR DESCRIPTION
As in title.